### PR TITLE
add software-properties-common

### DIFF
--- a/doc/build-unix.md
+++ b/doc/build-unix.md
@@ -76,6 +76,7 @@ If that doesn't work, you can install all boost development packages with:
 BerkeleyDB is required for the wallet. db4.8 packages are available [here](https://launchpad.net/~bitcoin/+archive/bitcoin).
 You can add the repository and install using the following commands:
 
+    sudo apt-get install software-properties-common
     sudo add-apt-repository ppa:bitcoin/bitcoin
     sudo apt-get update
     sudo apt-get install libdb4.8-dev libdb4.8++-dev


### PR DESCRIPTION
software-properties-common is the aptitude addon needed for add-apt-repository
not all distros include software-properties-common at the get go