### PR TITLE
Change PrivateSendAmount default value in UI from 2k to 2M

### DIFF
--- a/src/qt/forms/optionsdialog.ui
+++ b/src/qt/forms/optionsdialog.ui
@@ -260,16 +260,16 @@
          <item>
           <widget class="QSpinBox" name="privateSendAmount">
            <property name="minimum">
-            <number>2</number>
-           </property>
-           <property name="maximum">
             <number>2000</number>
            </property>
+           <property name="maximum">
+            <number>2000000</number>
+           </property>
            <property name="singleStep">
-            <number>10</number>
+            <number>10000</number>
            </property>
            <property name="value">
-            <number>1000</number>
+            <number>1000000</number>
            </property>
           </widget>
          </item>


### PR DESCRIPTION
https://github.com/biblepay/biblepay/commit/006d3bd992a58e23e850af5c64b5e381f74da747
When 1.0.9.2 (Increase PrivateSend Mixing Denominations by 1000) was commited, UI values were not updated. Updating now.