### PR TITLE
Update build notes to include instructions RandomX

### DIFF
--- a/doc/build-generic.md
+++ b/doc/build-generic.md
@@ -34,6 +34,10 @@ Please read the [depends](../depends/README.md) documentation for more details o
 options. If no host is specified (as in the above example) when calling `make`, the depends system will default to your
 local host system. 
 
+Building RandomX library
+---------------------
+Before you can build Biblepay core, be sure to complile the RandomX library found at src/crypto/RandomX. Instructions can be found [here](https://github.com/biblepay/biblepay/tree/master/src/crypto/RandomX)
+
 Building BiblePay Core
 ---------------------
 


### PR DESCRIPTION
When building the new version of Biblepay core, I noticed that I was receiving errors during the final `make` stage of compilation. It looks like the RandomX library needs to be compiled separately before you Make Biblepaycore, at least for Ubuntu 16+ . It was confusing to work this out, so I have added a link to the instructions in the build notes.